### PR TITLE
remove __sha256__* suffix from completion options

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -73,6 +73,7 @@ function! s:ProsessionComplete(ArgLead, Cmdline, Cursor) "{{{1
     let flead = empty(a:ArgLead) ? '' : '*' . a:ArgLead
     let flist = glob(fnamemodify(g:prosession_dir, ':p') . flead . '*.vim', 0, 1)
     let flist = map(flist, "fnamemodify(v:val, ':t:r')")
+    let flist = map(flist, "strpart(v:val, 0, strridx(v:val, '__sha256__'))")
   endif
   return flist
 endfunction


### PR DESCRIPTION
small patch so that completion options offered up when hitting `<Tab>` in a `:Prosession` command cut off the `__sha256__*` part of the filename, making completions a bit more usable since you can see more of them. Not sure what problems this will cause, if any, if there are multiple sessions with the same base name before the `__sha256__*` part, and since the whole point of that part is to avoid overlapping names that's probably worth thinking about. not sure how you want to handle it.