### PR TITLE
Escape filenames in :execute commands

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -47,7 +47,7 @@ function! s:Prosession(name) "{{{1
   silent noautocmd bufdo bw
   let sname = s:GetSessionFile(expand(a:name))
   if filereadable(sname)
-    silent execute 'source' sname
+    silent execute 'source' escape(sname, ' ')
   elseif isdirectory(expand(a:name))
     execute 'cd' expand(a:name)
   else
@@ -62,7 +62,7 @@ function! s:Prosession(name) "{{{1
     let sfname = s:GetSessionFileName(a:name)
     call system('tmux rename-window "vim - ' . sfname[:stridx(sfname, '__sha256__')-1] . '"')
   endif
-  silent execute 'Obsession' sname
+  silent execute 'Obsession' escape(sname,' ')
 endfunction
 
 function! s:ProsessionComplete(ArgLead, Cmdline, Cursor) "{{{1


### PR DESCRIPTION
This change escapes the filename passed to :Obsession, preventing an
error when the directory name contains a space.

Fixes #6.
