### PR TITLE
Fixed Function s:Prosession Recursive invoke hell and create session dir if dir not exists

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -71,6 +71,11 @@ function! s:Prosession(name) "{{{1
     silent Obsession " Stop current session
   endif
   silent! noautocmd bufdo bw
+
+  if !isdirectory(fnamemodify(g:prosession_dir, ':p'))
+      call mkdir(fnamemodify(g:prosession_dir, ':p'), 'p')
+  endif
+
   let sname = s:GetSessionFile(expand(a:name))
   if filereadable(sname)
     silent execute 'source' fnameescape(sname)
@@ -79,7 +84,7 @@ function! s:Prosession(name) "{{{1
   else
     if g:prosession_default_session
       let sname = s:GetSessionFile('default')
-      return s:Prosession(sname)
+      "return s:Prosession(sname)
     else
       let sname = s:GetSessionFile()
     endif


### PR DESCRIPTION
Hi, thanks for the useful plugin :+1: 

I got the following two issues when using this plugin:

1. if g:prosession_default_session = 1, function s:Prosession will be invoked again and again...
2. if session dir is not created manully, there will be an error says "xxxx file not readable" and session file will not be created.

so, i commented the line that s:Prosession recursive and add a piece of code to create session dir if dir not exists.