### PR TITLE
Fix unneeded session file name truncation

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -50,7 +50,7 @@ function! s:GetSessionFileName(...) "{{{1
     return fnamemodify(l:fname, ':t:r')
   endif
   let l:fname =  call('s:GetDirName', a:000)
-  return s:StripTrailingSlash(fname)
+  return s:StripTrailingSlash(l:fname)
 endfunction
 
 function! s:GetSessionFile(...) "{{{1

--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -45,9 +45,12 @@ function! s:GetDirName(...) "{{{1
 endfunction
 
 function! s:GetSessionFileName(...) "{{{1
-  let fname = a:0 && a:1 =~# '\.vim$' ? a:1 : call('s:GetDirName', a:000)
-  let fname = s:StripTrailingSlash(fname)
-  return fnamemodify(fname, ':t:r')
+  if a:0 && a:1 =~# '\.vim$'
+    let l:fname = a:1
+    return fnamemodify(l:fname, ':t:r')
+  endif
+  let l:fname =  call('s:GetDirName', a:000)
+  return s:StripTrailingSlash(fname)
 endfunction
 
 function! s:GetSessionFile(...) "{{{1


### PR DESCRIPTION
Hi! 
First of all, thanks for very useful plugin. I've noticed that when project directory name contains dots, like 'bitbucket.org' etc., session file name gets truncated, due to `fnamemodify('%:t:r')`. I've fixed this by separating logic for directory name and session file name in `s:GetSessionFileName()`.

Best regards,
Andrew.