### PR TITLE
Move command completion function to autoload file

### DIFF
--- a/autoload/prosession.vim
+++ b/autoload/prosession.vim
@@ -7,3 +7,16 @@ function! prosession#GetCurrBranch(dir) "{{{1
   if branch =~# "\n$" | let branch = branch[:-2] | endif
   return branch
 endfunction
+
+function! prosession#ProsessionComplete(ArgLead, Cmdline, Cursor) "{{{1
+  let fldr = fnamemodify(expand(a:ArgLead), ':h')
+  if !empty(a:ArgLead) && fldr != '.' && isdirectory(fldr)
+    let flist = glob(a:ArgLead . '*', 0, 1)
+  else
+    let flead = empty(a:ArgLead) ? '' : '*' . a:ArgLead
+    let flist = glob(fnamemodify(g:prosession_dir, ':p') . flead . '*.vim', 0, 1)
+    let flist = map(flist, "fnamemodify(v:val, ':t:r')")
+  endif
+  let flist = map(flist, "substitute(v:val, '%', '/', 'g')")
+  return flist
+endfunction

--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -92,19 +92,6 @@ function! s:Prosession(name) "{{{1
   silent execute 'Obsession' fnameescape(sname)
 endfunction
 
-function! s:ProsessionComplete(ArgLead, Cmdline, Cursor) "{{{1
-  let fldr = fnamemodify(expand(a:ArgLead), ':h')
-  if !empty(a:ArgLead) && fldr != '.' && isdirectory(fldr)
-    let flist = glob(a:ArgLead . '*', 0, 1)
-  else
-    let flead = empty(a:ArgLead) ? '' : '*' . a:ArgLead
-    let flist = glob(fnamemodify(g:prosession_dir, ':p') . flead . '*.vim', 0, 1)
-    let flist = map(flist, "fnamemodify(v:val, ':t:r')")
-  endif
-  let flist = map(flist, "substitute(v:val, '%', '/', 'g')")
-  return flist
-endfunction
-
 " Start / Load session {{{1
 if !argc() && g:prosession_on_startup
   augroup Prosession
@@ -116,4 +103,4 @@ if !argc() && g:prosession_on_startup
 endif
 
 " Command Prosession {{{1
-command! -bar -nargs=1 -complete=customlist,s:ProsessionComplete Prosession call s:Prosession(<q-args>)
+command! -bar -nargs=1 -complete=customlist,prosession#ProsessionComplete Prosession call s:Prosession(<q-args>)


### PR DESCRIPTION
This PR moves completion function of `Prosession` command's arguments to autoload file for being able to use it in NeoBundle lazy loaded plugin declaration.

[NeoBundle](https://github.com/Shougo/neobundle.vim) provides a way to lazy load plugin on invoking its' command in which command completion could be also handled by NeoBundle (before plugin will be loaded). `customlist` completion is supported, but only if completion function is accessible.

Script-local function is not accessible by definition, but autoloadable function could be used by NeoBundle.