### PR TITLE
Make use of ProjectRootGues if it is available

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -36,12 +36,16 @@ function! s:StripTrailingSlash(name) "{{{1
 endfunction
 
 function! s:GetDirName(...) "{{{1
-  let cwd = a:0 ? a:1 : getcwd()
-  let cwd = s:StripTrailingSlash(cwd)
-  if g:prosession_per_branch
-    let cwd .= '_' . prosession#GetCurrBranch(cwd)
+  if a:0
+    let dir = a:1
+  else
+    let dir = exists('*ProjectRootGuess') ? ProjectRootGuess() : getcwd()
   endif
-  return s:undofile(cwd)
+  let dir = s:StripTrailingSlash(dir)
+  if g:prosession_per_branch
+    let dir .= '_' . prosession#GetCurrBranch(dir)
+  endif
+  return s:undofile(dir)
 endfunction
 
 function! s:GetSessionFileName(...) "{{{1


### PR DESCRIPTION
Fixes https://github.com/dhruvasagar/vim-prosession/issues/19.

Feel free to close it (based on https://github.com/dhruvasagar/vim-prosession/issues/19#issuecomment-206381874), but I wanted to put it here, since I had done it already.