### PR TITLE
Fix 'Undefined variable dir' in s:GetDirName

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -40,7 +40,7 @@ function! s:GetCWD()
 endfunction
 
 function! s:GetDirName(...) "{{{1
-  let cwd = a:0 ? a:1 : s:GetCWD()
+  let dir = a:0 ? a:1 : s:GetCWD()
   let dir = s:StripTrailingSlash(dir)
   if g:prosession_per_branch
     let dir .= '_' . prosession#GetCurrBranch(dir)


### PR DESCRIPTION
Introduced in https://github.com/dhruvasagar/vim-prosession/commit/8ed193821f62ab14fc985ace6c23545ec3093cf6.