### PR TITLE
Rename correct tmux window

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -65,7 +65,7 @@ function! s:SetTmuxWindowName(name) "{{{1
     let sfname = sfname[strridx(sfname,'%')+1:]
     let title = substitute(g:prosession_tmux_title_format, '@@@', sfname, 'g')
     let title = substitute(title, '"', '\\"', 'g')
-    call system('tmux rename-window "' . title . '"')
+    call system('tmux rename-window -t ' . $TMUX_PANE . ' "' . title . '"')
     augroup ProsessionTmux
       autocmd!
 

--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -61,7 +61,7 @@ endfunction
 
 function! s:SetTmuxWindowName(name) "{{{1
   if g:prosession_tmux_title
-    let sfname = fnamemodify(s:GetSessionFileName(a:name), ':r')
+    let sfname = s:GetSessionFileName(a:name)
     let sfname = sfname[strridx(sfname,'%')+1:]
     let title = substitute(g:prosession_tmux_title_format, '@@@', sfname, 'g')
     let title = substitute(title, '"', '\\"', 'g')


### PR DESCRIPTION
Renames the tmux window that vim is in, instead of the one that is currently active