### PR TITLE
Ignore shellslash on nix

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -30,7 +30,7 @@ if !isdirectory(fnamemodify(g:prosession_dir, ':p'))
 endif
 
 function! s:undofile(cwd) "{{{1
-  if !&shellslash || has('win16') || has('win32') || has('win64')
+  if (has('shellslash') && !&shellslash) || has('win16') || has('win32') || has('win64')
     return substitute(a:cwd, '\', '%', 'g')
   else
     return substitute(a:cwd, '/', '%', 'g')


### PR DESCRIPTION
The fix for #37 broke the naming of files on non-Windows systems (or at least mine…). I'm not really sure what shellslash does, but this PR checks that the option exists before it uses the value of it.