### PR TITLE
Fix wiping of existing buffers

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -121,7 +121,8 @@ function! s:Prosession(name) "{{{1
   if !empty(get(g:, 'this_obsession', ''))
     silent Obsession " Stop current session
   endif
-  silent! noautocmd bufdo bw
+  " Remove all current buffers.
+  exe 'noautocmd bwipe '.join(filter(range(1, bufnr('$')), 'bufexists(v:val)'))
   if filereadable(sname)
     silent execute 'source' fnameescape(sname)
   elseif isdirectory(expand(a:name))


### PR DESCRIPTION
The current `silent! noautocmd bufdo bw` might hang waiting for input
when a swap file gets detected (E325), caused by `:bufdo bwipe` loading
previously unloaded buffers, and the `:silent!` then hides the
error/warning, but Vim waits for input still by default (when not using
SwapExists/v:swapchoice).

This patch uses `bwipe` with a list of existing buffers, which does not
trigger E325.

It does not use `:silent` intentionally, to get a message about buffers
being wiped.