### PR TITLE
Guard against wiping out a [NULL] buffer

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -155,7 +155,7 @@ function! s:Prosession(name) "{{{1
     silent Obsession " Stop current session
   endif
   " Remove all current buffers.
-  %bwipe!
+  silent! %bwipe!
   if filereadable(sname)
     silent execute 'source' fnameescape(sname)
   elseif isdirectory(expand(a:name))


### PR DESCRIPTION
This change fixes a warning upon running prosession in a new empty
buffer or on vim startup