### PR TITLE
Don't load/start if vim was started with any flags

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -209,7 +209,7 @@ function! s:save_last_session()
 endfunction
 
 " Start / Load session {{{1
-if !argc() && g:prosession_on_startup
+if !argc() && len(v:argv) < 2 && g:prosession_on_startup
   augroup Prosession
     au!
 


### PR DESCRIPTION
- Fixes #84

Something to consider, it might be better to do this check in a different place, then sessions would still automatically be saved after launching vim in this way.
