### PR TITLE
Only prevent autoload if -q arg exists

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -214,7 +214,7 @@ function! s:save_last_session()
 endfunction
 
 " Start / Load session {{{1
-if !argc() && len(v:argv) < 2 && g:prosession_on_startup
+if !argc() && index(argv(), '-q') == -1 && g:prosession_on_startup
   augroup Prosession
     au!
 


### PR DESCRIPTION
Reverting my previous change based on #88 

Also switched from `v:argv` to `argv()` for compatibility with older versions of vim/nvim. Fixes #87 

This probably needs more thought but I'm pushing for visibility.