### PR TITLE
Revert argv() to v:argv

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -214,7 +214,13 @@ function! s:save_last_session()
 endfunction
 
 " Start / Load session {{{1
-if !argc() && index(argv(), '-q') == -1 && g:prosession_on_startup
+if has("nvim-0.6.1") || has("patch-8.1-2233")
+  let s:should_load_session = index(v:argv, '-q') == 1 ? 0 : 1
+else
+  let s:should_load_session = index(argv(), '-q') == 1 ? 0 : 1
+endif
+
+if !argc() && s:should_load_session && g:prosession_on_startup
   augroup Prosession
     au!
 

--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -217,7 +217,8 @@ endfunction
 if has("nvim-0.6.1") || has("patch-8.1-2233")
   let s:should_load_session = index(v:argv, '-q') == 1 ? 0 : 1
 else
-  let s:should_load_session = index(argv(), '-q') == 1 ? 0 : 1
+  let s:vargv_workaround = split(system("ps -o command= -p " . getpid()))
+  let s:should_load_session = index(s:vargv_workaround, '-q') == 1 ? 0 : 1
 endif
 
 if !argc() && s:should_load_session && g:prosession_on_startup


### PR DESCRIPTION
I mistakenly switched this to argv() when I reverted my original change in #89 

This seemingly breaks `git jump grep 'some_string'` again (#84), the whole purpose of my original PR in #85 😆 

Tested working on vim 8.2 and neovim 0.4.4/0.7