### PR TITLE
Add per session viminfo file. Fixes #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VIM ProSession v0.7.0
+# VIM ProSession v0.7.1
 
 A VIM plugin to handle sessions like a pro.
 

--- a/doc/prosession.txt
+++ b/doc/prosession.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------------
                                  VIM ProSession
 
-                   Handle sessions like a PRO. Version 0.7.0
+                   Handle sessions like a PRO. Version 0.7.1
 
               Repo: https://github.com/dhruvasagar/vim-prosession
                  Author: Dhruva Sagar <http://dhruvasagar.com/>
@@ -91,6 +91,14 @@ g:Prosession_ignore_expr
                       directories that are not git repos. >
                         let g:Prosession_ignore_expr = {-> !isdirectory('.git')}
 <
+
+                                            *g:prosession_viminfo_per_session*
+g:prosession_viminfo_per_session
+                      This is disabled by default. You can use this to enable
+                      a per session viminfo file. >
+                        let g:prosession_viminfo_per_session = v:true
+<
+
 ------------------------------------------------------------------------------
 USAGE                                                              *:Prosession*
 

--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -32,6 +32,7 @@ call s:SetGlobalOptDefault('prosession_tmux_title_format', 'vim - @@@')
 call s:SetGlobalOptDefault('prosession_last_session_dir', '')
 call s:SetGlobalOptDefault('prosession_ignore_dirs', [])
 call s:SetGlobalOptDefault('Prosession_ignore_expr', {->v:false})
+call s:SetGlobalOptDefault('prosession_viminfo_per_session', v:false)
 
 let s:save_last_on_leave = g:prosession_on_startup
 
@@ -90,6 +91,11 @@ endfunction
 
 function! s:GetSessionFile(...) "{{{1
   let sname = call('s:GetSessionFileName', a:000) . '.vim'
+  return fnamemodify(g:prosession_dir, ':p') . sname
+endfunction
+
+function! s:GetVimInfoFile(...) "{{{1
+  let sname = call('s:GetSessionFileName', a:000) . '.viminfo'
   return fnamemodify(g:prosession_dir, ':p') . sname
 endfunction
 
@@ -189,6 +195,9 @@ function! s:Prosession(...) "{{{1
     let g:prosession_last_session_file = sname
   endif
   silent execute 'Obsession' fnameescape(sname)
+  if g:prosession_viminfo_per_session
+    exec 'set viminfofile=' . s:GetVimInfoFile()
+  endif
   " Restore last session saving
   let s:save_last_on_leave = g:prosession_on_startup
   if exists('#User#ProsessionPost')


### PR DESCRIPTION
You can enable this by setting `g:prosession_viminfo_per_session` to `v:true` in your .vimrc