### PR TITLE
Auto Switch for change in git branch. Fixes #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VIM ProSession v0.7.1
+# VIM ProSession v0.7.2
 
 A VIM plugin to handle sessions like a pro.
 

--- a/doc/prosession.txt
+++ b/doc/prosession.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------------
                                  VIM ProSession
 
-                   Handle sessions like a PRO. Version 0.7.1
+                   Handle sessions like a PRO. Version 0.7.2
 
               Repo: https://github.com/dhruvasagar/vim-prosession
                  Author: Dhruva Sagar <http://dhruvasagar.com/>
@@ -57,6 +57,12 @@ g:prosession_per_branch
                       per git branch sessions. >
                         let g:prosession_per_branch = 0
 <
+
+                      If this is enabled, and you have `tpope/vim-fugitive`
+                      installed, prosession will also automatically switch to
+                      the git branch's session when you checkout a branch
+                      using the `:Git checkout` command.
+
                                                      *g:prosession_branch_cmd*
 g:prosession_branch_cmd
                       This defines the shell command to use to determine the

--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -245,6 +245,25 @@ function! s:AutoStart()
   call s:Prosession(sname)
 endfunction
 
+function! s:AutoSwitch()
+  if g:prosession_per_branch && exists('*FugitiveResult')
+    let fresult = FugitiveResult()
+    if !empty(fresult)
+          \ && has_key(fresult, 'args')
+          \ && !empty(fresult['args'])
+          \ && fresult['args'][0] ==? 'checkout'
+          \ && len(fresult['args']) > 1
+      call s:AutoStart()
+    endif
+  endif
+endfunction
+
+augroup ProsessionGit
+  au!
+
+  autocmd User FugitiveChanged call s:AutoSwitch()
+augroup END
+
 " Command Prosession {{{1
 command! -bar -nargs=? -complete=customlist,prosession#ProsessionComplete Prosession call s:Prosession(<q-args>)
 "


### PR DESCRIPTION
If you enable per branch by setting `let g:prosession_per_branch = 1`, when you switch to a different git branch using `:Git checkout`, we will automatically switch to the session corresponding to that branch.

This feature depends on `tpope/vim-fugitive`.