### PR TITLE
Fix last session file for a prosession_dir with no trailing slash

### DIFF
--- a/plugin/prosession.vim
+++ b/plugin/prosession.vim
@@ -207,14 +207,14 @@ endfunction
 
 function! s:GetLastSessionFile()
   try
-    return g:prosession_dir . trim(readfile(s:LastSession())[0])
+    return fnamemodify(g:prosession_dir, ':p') . trim(readfile(s:LastSession())[0])
   catch
     return ""
   endtry
 endfunction
 
 function! s:LastSession()
-  return expand(g:prosession_dir . "last_session.txt")
+  return fnamemodify(g:prosession_dir, ':p') . "last_session.txt"
 endfunction
 
 function! s:save_last_session()


### PR DESCRIPTION
When setting `g:prosession_dir` to a custom directory without a trailing slash, this causes the last session file to be saved as `<directory>last_session.txt` (notice no `/` between `<directory>` and `last_session.txt`.

This PR uses the `fnamemodify` to ensure a path separator is appended at the end (while still expanding `~`).

With my configuration, I had:
```
init = function()
    vim.g.prosession_dir = vim.fn.stdpath("data") .. "/site/session"
end,
```
which caused the last_session file to be saved under `~/.local/share/nvim/site/sessionlast_session.txt`.